### PR TITLE
bugfix in settings screen: key S should not trigger save in georam naming mode

### DIFF
--- a/c64screen.cpp
+++ b/c64screen.cpp
@@ -752,7 +752,7 @@ void handleC64( int k, u32 *launchKernel, char *FILENAME, char *filenameKernal )
 				curSettingsLine = MAX_SETTINGS - 1; else
 				curSettingsLine --;
 		}
-		if( k == 's' || k == 'S' )
+		if( (k == 's' || k == 'S') && typeInName == 0 )
 		{
 			writeSettingsFile();
 			errorMsg = errorMessages[ 4 ];


### PR DESCRIPTION
While we name a Georam slot we don't want "S" to save.